### PR TITLE
Update scanner version 4.6.2.2472

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: philipssoftware/sonar-scanner:4.3
+    container: philipssoftware/sonar-scanner:4.6.2.2472
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## Unreleased
+
+- Use scanner version 4.6.2.2472
+
+## v1.2.0 
+
+- Use scanner version 4.4.0.2170
+
 ## v1.1.0 - 2020-09-11
 
 - [#8] - Add support for Community Edition. Thanks @vmaggioli !

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM philipssoftware/sonar-scanner:4.4.0.2170
+FROM philipssoftware/sonar-scanner:4.6.2.2472
 COPY . /actions/sonar-scanner-action
 
 ENTRYPOINT ["node", "/actions/sonar-scanner-action/dist/index.js"]

--- a/README.MD
+++ b/README.MD
@@ -32,6 +32,16 @@ The action support the following features
 | --------------- | :--------------------------------------- |
 | sonarParameters | Sonar parameters generate based on input |
 
+## Environment
+
+| Tool         | Version    |
+| ------------ | :--------- |
+| SonarScanner | 4.6.2.2472 |
+| Java         | 11.0.11    |
+| Node         | v16.4.2    |
+| Python       | 2.7.16     |
+| Python       | 3.7.3      |
+
 ## Sample Configuration
 
 To prevent your token from showing in the runner's output, it is advised to store the token configuration inside of a github secret variable.

--- a/dist/index.js
+++ b/dist/index.js
@@ -657,7 +657,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -670,7 +670,7 @@ function getBranchOrTagName(githubRef) {
     const githubRefParts = githubRef.split('/');
     return githubRefParts[githubRefParts.length - 1];
 }
-exports.sonarScanner = async () => {
+const sonarScanner = async () => {
     const projectName = core.getInput('projectName', { required: true });
     const projectKey = core.getInput('projectKey', { required: true });
     const baseDir = core.getInput('baseDir', { required: false });
@@ -760,6 +760,7 @@ exports.sonarScanner = async () => {
         core.setOutput('sonarParameters', sonarParameters.join(' '));
     }
 };
+exports.sonarScanner = sonarScanner;
 
 
 /***/ }),
@@ -7598,7 +7599,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };


### PR DESCRIPTION
# Changes
Update version of SonarScanner

# Side effects
This change will also update some build tools.

## Versions
| Tool         | Version    |
| ------------ | :--------- |
| SonarScanner | 4.6.2.2472 |
| Java         | 11.0.11    |
| Node         | v16.4.2    |
| Python       | 2.7.16     |
| Python       | 3.7.3      |

## Older versions
If your project is not able to use these environments you can still use the v1.2.0 version of this scanner action.
`philips-software/sonar-scanner-action@v1.2.0`

